### PR TITLE
Fix syntax error in error handling code

### DIFF
--- a/thecampy/models.py
+++ b/thecampy/models.py
@@ -62,7 +62,7 @@ class Soldier:
         }
     
 
-        if not unit_codes[unit]:
+        if unit not in unit_codes:
             raise thecampyValueError('해당 사단/육군훈련소 연대가 존재하지 않습니다.')
 
         


### PR DESCRIPTION
기존 코드는 존재하지 않는 unit 값이 들어올 시, if문의 검사에서 KeyError를 띄우게 됩니다.
의도된 방식으로의 동작을 위한 수정입니다.