### PR TITLE
Exception 처리 버그 수정

### DIFF
--- a/thecampy/models.py
+++ b/thecampy/models.py
@@ -62,7 +62,7 @@ class Soldier:
         }
     
 
-        if not unit_codes[unit]:
+        if unit not in unit_codes:
             raise thecampyValueError('해당 사단/육군훈련소 연대가 존재하지 않습니다.')
 
         

--- a/thecampy/models.py
+++ b/thecampy/models.py
@@ -60,12 +60,10 @@ class Soldier:
             '육군훈련소(29연대)' : '20020192300',
             '육군훈련소(30연대)' : '20020192400',
         }
-    
 
         if unit not in unit_codes:
-            raise thecampyValueError('해당 사단/육군훈련소 연대가 존재하지 않습니다.')
+            raise exceptions.ThecampyValueError('해당 사단/육군훈련소 연대가 존재하지 않습니다.')
 
-        
         self.name = name
         self.bday = bday
         self.enlist_date = enlist_date


### PR DESCRIPTION
1. unit이 unit_codes에 없을 경우를 제대로 처리하도록 if문의 조건을 변경했으며,
2. Error의 이름을 적절히 수정하여 제대로 된 호출이 일어날 수 있도록 수정했습니다.