### PR TITLE
부대이름 항목 삭제

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ thecampy는 [parksb/the-camp-lib](https://github.com/parksb/the-camp-lib)을 참
 
             [입대일(yyyymmdd)],
 
-            [부대(육군훈련소(30연대)],
-
     )
 
     msg = thecampy.Message([제목], [내용(1500자 이하)])
@@ -50,7 +48,7 @@ thecampy는 [parksb/the-camp-lib](https://github.com/parksb/the-camp-lib)을 참
 # sample
     import thecampy
 
-    my_soldier = thecampy.Soldier('홍길동',20010101,20210225,'육군훈련소(23연대)',)
+    my_soldier = thecampy.Soldier('홍길동',20010101,20210225)
 
     msg = thecampy.Message(['테스트 제목'], ['테스트 내용'])
 
@@ -68,8 +66,6 @@ thecampy는 [parksb/the-camp-lib](https://github.com/parksb/the-camp-lib)을 참
 ## 주의사항
 
 - 더 캠프 계정은 이메일로 가입되어있어야 합니다. (카카오계정 지원 X)
-
-- 부대이름을 정확히 입력해야합니다. ex) 육군훈련소(00연대), 7사단, 22사단...
 
 - 인터넷편지는 '예비군인/훈련병'에게만 보낼 수 있습니다.
 

--- a/thecampy/models.py
+++ b/thecampy/models.py
@@ -62,7 +62,7 @@ class Soldier:
         }
     
 
-        if not unit_codes[unit]:
+        if unit not in unit_codes:
             raise thecampyValueError('해당 사단/육군훈련소 연대가 존재하지 않습니다.')
 
         

--- a/thecampy/models.py
+++ b/thecampy/models.py
@@ -20,7 +20,7 @@ class Cookie:
         return self.token
 
 class Soldier:
-    def __init__(self, name, bday, enlist_date, unit):
+    def __init__(self, name, bday, enlist_date, unit=None):
 
         unit_codes = {
             '1사단' : '20121290100',
@@ -61,8 +61,12 @@ class Soldier:
             '육군훈련소(30연대)' : '20020192400',
         }
 
-        if unit not in unit_codes:
-            raise exceptions.ThecampyValueError('해당 사단/육군훈련소 연대가 존재하지 않습니다.')
+        if unit is None:
+            unit_code = None
+        else:
+            if unit not in unit_codes:
+                raise exceptions.ThecampyValueError('해당 사단/육군훈련소 연대가 존재하지 않습니다.')
+            unit_code = unit_codes[unit]
 
         self.name = name
         self.bday = bday
@@ -71,8 +75,8 @@ class Soldier:
         self.identity_code = '0000490001'
         self.army = '0000010001' #육군 코드
         self.unit = unit
-        self.unit_code = unit_codes[unit]
-        
+        self.unit_code = unit_code
+
     
     def add_soldier_code(self, code):
         self.soldier_code = code

--- a/thecampy/models.py
+++ b/thecampy/models.py
@@ -60,12 +60,10 @@ class Soldier:
             '육군훈련소(29연대)' : '20020192300',
             '육군훈련소(30연대)' : '20020192400',
         }
-    
 
         if unit not in unit_codes:
-            raise thecampyValueError('해당 사단/육군훈련소 연대가 존재하지 않습니다.')
+            raise exceptions.ThecampyValueError('해당 사단/육군훈련소 연대가 존재하지 않습니다.')
 
-        
         self.name = name
         self.bday = bday
         self.enlist_date = enlist_date


### PR DESCRIPTION
현재 README 파일에서는, 라이브러리의 사용을 위해 정확한 부대 이름이 필요하다는 내용이 있습니다.

하지만 이는 더 이상 사실이 아닌 듯 합니다. (the-camp-lib의 약 1년 전 업데이트 참고: https://github.com/parksb/the-camp-lib/commit/6541f843ac45e62cd7038b7b673d841d78da6507)

부대 이름을 입력하지 않아도 코드가 동작할 수 있도록, `models.Soldier`의 생성자에서 `unit`값을 optional하게 변경하였습니다.
또한 README.md에서 부대명에 대한 언급을 삭제했습니다.
`unit`값이 기존과 같이 입력될 상황을 대비해, 기존의 코드는 삭제하지 않아 이전 코드와의 호환성을 남겨두었습니다.

본 변경사항 없이도 라이브러리가 정상동작하긴 하나, 라이브러리 사용자들이 부대이름 값을 어떻게 설정해야 하는지 불필요하게 고민하는 부분을 줄일 수 있을 것 같아 PR 올립니다.