### PR TITLE
Fix: __init__ returns non-None

### DIFF
--- a/thecampy/client.py
+++ b/thecampy/client.py
@@ -44,11 +44,6 @@ class Client:
         if (self.cookie.iuid == False or self.cookie.token == False):
             raise exceptions.ThecampyException('알 수 없는 에러 {}'.format(r.json()))
         
-        return {
-            'iuid' : self.cookie.iuid,
-            'token' : self.cookie.token
-        }
-
     def _enforce_login(self):
         if not hasattr(self, 'cookie'):
             raise exceptions.ThecampyValueError("로그인이 필요합니다.")


### PR DESCRIPTION
- 개요: 
  - `Client`의 `__init__`함수가 None이 아닌  return 값을 가져 오류가 발생합니다.
- 관련 이슈:
  - #10
- 수정사항: 
  - 리턴값을 제거하였습니다.